### PR TITLE
Rename metrics dir to not be sigar specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ spark.eventLog.dir               hdfs://127.0.0.1:9000/spark-logs
 Also in spark-defaults.conf you should specify the folder from which the UI will read the metrics:
 
 ```
-spark.sigar.dir                  hdfs://127.0.0.1:9000/custom-metrics
+spark.hdfs.metrics.dir           hdfs://127.0.0.1:9000/custom-metrics
 ```
 
 ## Notes about the metrics
@@ -186,7 +186,7 @@ Number of Kilobytes read/written from/to the disk per second
 
 # **Important**: 
 
-The folders spark.eventLog.dir, sigar.sink.hdfs.dir and spark.sigar.dir must already exist in the HDFS.
+The folders spark.eventLog.dir, executor.sink.hdfs.dir and spark.hdfs.metrics.dir must already exist in the HDFS.
 
 You should increase the limit for open files on the operating systems of the Master and the Workers.
 

--- a/conf/spark-defaults.conf.template
+++ b/conf/spark-defaults.conf.template
@@ -22,7 +22,7 @@
 # spark.master                     spark://master:7077
 # spark.eventLog.enabled           true
 # spark.eventLog.dir               hdfs://namenode:8021/directory
-# spark.sigar.dir                  hdfs://namenode:8021/custom-metrics
+# spark.hdfs.metrics.dir           hdfs://namenode:8021/custom-metrics
 # spark.serializer                 org.apache.spark.serializer.KryoSerializer
 # spark.driver.memory              5g
 # spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -968,7 +968,7 @@ private[deploy] class Master(
       val replayBus = new ReplayListenerBus()
       val hdfsExecutorMetricsReplayBus : Option[HDFSExecutorMetricsReplayListenerBus] = Some(new HDFSExecutorMetricsReplayListenerBus())
 
-      val customMetricsPath = conf.get("spark.sigar.dir","hdfs://localhost:9000/custom-metrics/");
+      val customMetricsPath = conf.get("spark.hdfs.metrics.dir","hdfs://localhost:9000/custom-metrics/");
       val jsonDirectory = new Path(customMetricsPath + "/" + app.id)
 
       var inputStreamsAndKeys = new ListBuffer[(InputStream,String)]


### PR DESCRIPTION
The spark.sigar.dir is really the hdfs metrics reporter dir so it is better to have a more general name
